### PR TITLE
Add Hibernate naming strategy to Objects config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# IntelliJ project files
+
+.idea
+*.iml
+out
+gen

--- a/smartcosmos-ext-objects-rdao.yml
+++ b/smartcosmos-ext-objects-rdao.yml
@@ -18,6 +18,7 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
+      naming_strategy: org.hibernate.cfg.EJB3NamingStrategy
 
 smartcosmos:
   security:


### PR DESCRIPTION
Just adds in a Hibernate naming strategy configuration to allow for camelCase columnNames again, like in Objects v2.
