### PR TITLE
Bugfix/validation query

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -18,7 +18,7 @@ smartcosmos:
   datasource:
     default-host: mysql
     default-username: cosmos
-    default-pasword: dev
+    default-password: dev
     default-db: devkit
   authorization-server: http://auth-server:8080
   event-header: "urn:smartcosmos://events:"

--- a/application.yml
+++ b/application.yml
@@ -15,6 +15,11 @@ kafka:
     address: ${kafka.zookeeper.host}:${kafka.zookeeper.port}
 
 smartcosmos:
+  datasource:
+    default-host: mysql
+    default-username: cosmos
+    default-pasword: dev
+    default-db: devkit
   authorization-server: http://auth-server:8080
   event-header: "urn:smartcosmos://events:"
 

--- a/smartcosmos-edge-user-devkit.yml
+++ b/smartcosmos-edge-user-devkit.yml
@@ -25,14 +25,6 @@ spring:
       ddl-auto: update
       naming_strategy: org.hibernate.cfg.EJB3NamingStrategy
 
-
-eureka:
-  client:
-    serviceUrl:
-      defaultZone: http://172.18.0.6:8080/eureka/
-    healthcheck:
-      enables: true
-
 smartcosmos:
   security:
     enabled: true

--- a/smartcosmos-edge-user-devkit.yml
+++ b/smartcosmos-edge-user-devkit.yml
@@ -13,12 +13,12 @@ spring:
     password: ${smartcosmos.datasource.default-password}
     driver-class-name: org.mariadb.jdbc.Driver
     ## XXX Note that in the migration to Spring Boot 1.4 these will need to move:
-    testOnBorrow: true
-    validationQuery: SELECT 1
+    test-on-borrow: true
+    validation-query: SELECT 1
     ## Uncomment for Spring Boot 1.4
     # tomcat:
-    #   testOnBorrow: true
-    #   validationQuery: SELECT 1
+    #   test-on-borrow: true
+    #   validation-query: SELECT 1
 # XXX Super dangerous to let this get to production.
   jpa:
     hibernate:

--- a/smartcosmos-edge-user-devkit.yml
+++ b/smartcosmos-edge-user-devkit.yml
@@ -8,16 +8,30 @@ spring:
     #
     # CREATE DATABASE devkit;  GRANT ALL PRIVILEGES ON devkit.* TO 'cosmos'@'localhost' IDENTIFIED BY 'dev';  FLUSH PRIVILEGES;
     #
-    url: jdbc:mysql://mysql/devkit?autoReconnect=true
-    username: cosmos
-    password: dev
+    url: jdbc:mysql://${smartcosmos.datasource.default-host}/${smartcosmos.datasource.default-db}
+    username: ${smartcosmos.datasource.default-username}
+    password: ${smartcosmos.datasource.default-password}
     driver-class-name: org.mariadb.jdbc.Driver
+    ## XXX Note that in the migration to Spring Boot 1.4 these will need to move:
+    testOnBorrow: true
+    validationQuery: SELECT 1
+    ## Uncomment for Spring Boot 1.4
+    # tomcat:
+    #   testOnBorrow: true
+    #   validationQuery: SELECT 1
 # XXX Super dangerous to let this get to production.
   jpa:
     hibernate:
       ddl-auto: update
       naming_strategy: org.hibernate.cfg.EJB3NamingStrategy
 
+
+eureka:
+  client:
+    serviceUrl:
+      defaultZone: http://172.18.0.6:8080/eureka/
+    healthcheck:
+      enables: true
 
 smartcosmos:
   security:

--- a/smartcosmos-ext-metadata.yml
+++ b/smartcosmos-ext-metadata.yml
@@ -19,12 +19,12 @@ spring:
     password: ${smartcosmos.datasource.default-password}
     driver-class-name: org.mariadb.jdbc.Driver
     ## XXX Note that in the migration to Spring Boot 1.4 these will need to move:
-    testOnBorrow: true
-    validationQuery: SELECT 1
+    test-on-borrow: true
+    validation-query: SELECT 1
     ## Uncomment for Spring Boot 1.4
     # tomcat:
-    #   testOnBorrow: true
-    #   validationQuery: SELECT 1
+    #   test-on-borrow: true
+    #   validation-query: SELECT 1
 # XXX Super dangerous to let this get to production.
   jpa:
     hibernate:

--- a/smartcosmos-ext-metadata.yml
+++ b/smartcosmos-ext-metadata.yml
@@ -14,10 +14,17 @@ spring:
     #
     # CREATE DATABASE devkit;  GRANT ALL PRIVILEGES ON devkit.* TO 'cosmos'@'localhost' IDENTIFIED BY 'dev';  FLUSH PRIVILEGES;
     #
-    url: jdbc:mysql://mysql/devkit?autoReconnect=true
-    username: cosmos
-    password: dev
+    url: jdbc:mysql://${smartcosmos.datasource.default-host}/${smartcosmos.datasource.default-db}
+    username: ${smartcosmos.datasource.default-username}
+    password: ${smartcosmos.datasource.default-password}
     driver-class-name: org.mariadb.jdbc.Driver
+    ## XXX Note that in the migration to Spring Boot 1.4 these will need to move:
+    testOnBorrow: true
+    validationQuery: SELECT 1
+    ## Uncomment for Spring Boot 1.4
+    # tomcat:
+    #   testOnBorrow: true
+    #   validationQuery: SELECT 1
 # XXX Super dangerous to let this get to production.
   jpa:
     hibernate:

--- a/smartcosmos-ext-relationships.yml
+++ b/smartcosmos-ext-relationships.yml
@@ -12,10 +12,17 @@ spring:
     #
     # CREATE DATABASE devkit;  GRANT ALL PRIVILEGES ON devkit.* TO 'cosmos'@'localhost' IDENTIFIED BY 'dev';  FLUSH PRIVILEGES;
     #
-    url: jdbc:mysql://mysql/devkit?autoReconnect=true
-    username: cosmos
-    password: dev
+    url: jdbc:mysql://${smartcosmos.datasource.default-host}/${smartcosmos.datasource.default-db}
+    username: ${smartcosmos.datasource.default-username}
+    password: ${smartcosmos.datasource.default-password}
     driver-class-name: org.mariadb.jdbc.Driver
+    ## XXX Note that in the migration to Spring Boot 1.4 these will need to move:
+    testOnBorrow: true
+    validationQuery: SELECT 1
+    ## Uncomment for Spring Boot 1.4
+    # tomcat:
+    #   testOnBorrow: true
+    #   validationQuery: SELECT 1
 # XXX Super dangerous to let this get to production.
   jpa:
     hibernate:

--- a/smartcosmos-ext-relationships.yml
+++ b/smartcosmos-ext-relationships.yml
@@ -17,12 +17,12 @@ spring:
     password: ${smartcosmos.datasource.default-password}
     driver-class-name: org.mariadb.jdbc.Driver
     ## XXX Note that in the migration to Spring Boot 1.4 these will need to move:
-    testOnBorrow: true
-    validationQuery: SELECT 1
+    test-on-borrow: true
+    validation-query: SELECT 1
     ## Uncomment for Spring Boot 1.4
     # tomcat:
-    #   testOnBorrow: true
-    #   validationQuery: SELECT 1
+    #   test-on-borrow: true
+    #   validation-query: SELECT 1
 # XXX Super dangerous to let this get to production.
   jpa:
     hibernate:

--- a/smartcosmos-ext-things.yml
+++ b/smartcosmos-ext-things.yml
@@ -15,12 +15,12 @@ spring:
     password: ${smartcosmos.datasource.default-password}
     driver-class-name: org.mariadb.jdbc.Driver
     ## XXX Note that in the migration to Spring Boot 1.4 these will need to move:
-    testOnBorrow: true
-    validationQuery: SELECT 1
+    test-on-borrow: true
+    validation-query: SELECT 1
     ## Uncomment for Spring Boot 1.4
     # tomcat:
-    #   testOnBorrow: true
-    #   validationQuery: SELECT 1
+    #   test-on-borrow: true
+    #   validation-query: SELECT 1
 # XXX Super dangerous to let this get to production.
   jpa:
     hibernate:

--- a/smartcosmos-ext-things.yml
+++ b/smartcosmos-ext-things.yml
@@ -10,10 +10,17 @@ spring:
     #
     # CREATE DATABASE devkit;  GRANT ALL PRIVILEGES ON devkit.* TO 'cosmos'@'localhost' IDENTIFIED BY 'dev';  FLUSH PRIVILEGES;
     #
-    url: jdbc:mysql://mysql/devkit?autoReconnect=true
-    username: cosmos
-    password: dev
+    url: jdbc:mysql://${smartcosmos.datasource.default-host}/${smartcosmos.datasource.default-db}
+    username: ${smartcosmos.datasource.default-username}
+    password: ${smartcosmos.datasource.default-password}
     driver-class-name: org.mariadb.jdbc.Driver
+    ## XXX Note that in the migration to Spring Boot 1.4 these will need to move:
+    testOnBorrow: true
+    validationQuery: SELECT 1
+    ## Uncomment for Spring Boot 1.4
+    # tomcat:
+    #   testOnBorrow: true
+    #   validationQuery: SELECT 1
 # XXX Super dangerous to let this get to production.
   jpa:
     hibernate:

--- a/smartcosmos-user-details-devkit.yml
+++ b/smartcosmos-user-details-devkit.yml
@@ -13,12 +13,12 @@ spring:
     password: ${smartcosmos.datasource.default-password}
     driver-class-name: org.mariadb.jdbc.Driver
     ## XXX Note that in the migration to Spring Boot 1.4 these will need to move:
-    testOnBorrow: true
-    validationQuery: SELECT 1
+    test-on-borrow: true
+    validation-query: SELECT 1
     ## Uncomment for Spring Boot 1.4
     # tomcat:
-    #   testOnBorrow: true
-    #   validationQuery: SELECT 1
+    #   test-on-borrow: true
+    #   validation-query: SELECT 1
   jpa:
     hibernate:
       ddl-auto: verify

--- a/smartcosmos-user-details-devkit.yml
+++ b/smartcosmos-user-details-devkit.yml
@@ -8,10 +8,17 @@ spring:
     #
     # CREATE DATABASE devkit;  GRANT ALL PRIVILEGES ON devkit.* TO 'cosmos'@'localhost' IDENTIFIED BY 'dev';  FLUSH PRIVILEGES;
     #
-    url: jdbc:mysql://mysql/devkit?autoReconnect=true
-    username: cosmos
-    password: dev
+    url: jdbc:mysql://${smartcosmos.datasource.default-host}/${smartcosmos.datasource.default-db}
+    username: ${smartcosmos.datasource.default-username}
+    password: ${smartcosmos.datasource.default-password}
     driver-class-name: org.mariadb.jdbc.Driver
+    ## XXX Note that in the migration to Spring Boot 1.4 these will need to move:
+    testOnBorrow: true
+    validationQuery: SELECT 1
+    ## Uncomment for Spring Boot 1.4
+    # tomcat:
+    #   testOnBorrow: true
+    #   validationQuery: SELECT 1
   jpa:
     hibernate:
       ddl-auto: verify


### PR DESCRIPTION
### What changes were proposed in this pull request?

Changes how we create database connections and adds in a validation query to make sure a database connection is valid before using the connection.
### How is this patch documented?

[5.1 Driver/Datasource Class Names, URL Syntax and Configuration Properties for Connector/J ](https://dev.mysql.com/doc/connector-j/5.1/en/connector-j-reference-configuration-properties.html) specifically this section (emphasis mine):

> autoReconnect
> 
> Should the driver try to re-establish stale and/or dead connections? **If enabled the driver will throw an exception for a queries issued on a stale or dead connection**, which belong to the current transaction, but will attempt reconnect before the next query issued on the connection in a new transaction. The use of this feature is not recommended, because it has side effects related to session state and data consistency when applications don't handle SQLExceptions properly, and is only designed to be used when you are unable to configure your application to handle SQLExceptions resulting from dead and stale connections properly. Alternatively, as a last option, investigate setting the MySQL server variable "wait_timeout" to a high value, rather than the default of 8 hours.
> 
> Default: false
> 
> Since version: 1.1
### How was this patch tested?

Manually tested, as the issue is regarding timeouts.  I guess we could create an automated test that waited a couple hours for database timeouts? :confused:
