### PR TITLE
Standardize Kafka and Zookeeper references.

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -9,20 +9,18 @@ management:
   # security:
   #   enabled: false
 
-kafka:
-  broker:
-    host: ${KAFKA_IP:172.17.0.3}
-    port: 9092
-    address: ${kafka.broker.host}:${kafka.broker.port}
-  zookeeper:
-    host: ${ZK_IP:172.17.0.2}
-    port: 2181
-    address: ${kafka.zookeeper.host}:${kafka.zookeeper.port}
-
 smartcosmos:
   service:
+    kafka:
+      host: ${KAFKA_HOST:'http://localhost'}
+      port: 9092
+      address: ${kafka.broker.host}:${kafka.broker.port}
+    zookeeper:
+      host: ${ZOOKEEPER_HOST:'http://localhost'}
+      port: 2181
+      address: ${kafka.zookeeper.host}:${kafka.zookeeper.port}
     gateway:
-      host: http://localhost
+      host: ${GATEWAY_HOST:'http://localhost'}
       port: 8080
       address: ${smartcosmos.service.gateway.host}:${smartcosmos.service.gateway.port}
     auth-server:


### PR DESCRIPTION
### What changes were proposed in this pull request?

Moves kafka and zookeeper to use the same service naming convention.

#### Depends On
Doesn't really DEPEND on, but for ease of use, please see Framework pull request that'll get mentioned in this thread.